### PR TITLE
libxslt 1.1.43

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,25 @@
 * text=auto
 
+*.patch binary
+*.diff binary
 meta.yaml text eol=lf
 build.sh text eol=lf
 bld.bat text eol=crlf
+
+# github helper pieces to make some files not show up in diffs automatically
+.azure-pipelines/* linguist-generated=true
+.circleci/* linguist-generated=true
+.drone/* linguist-generated=true
+.drone.yml linguist-generated=true
+.github/* linguist-generated=true
+.travis/* linguist-generated=true
+.appveyor.yml linguist-generated=true
+.gitattributes linguist-generated=true
+.gitignore linguist-generated=true
+.travis.yml linguist-generated=true
+.scripts/* linguist-generated=true
+LICENSE.txt linguist-generated=true
+README.md linguist-generated=true
+azure-pipelines.yml linguist-generated=true
+build-locally.py linguist-generated=true
+shippable.yml linguist-generated=true

--- a/recipe/0001-Make-and-install-a-pkg-config-file-on-Windows.patch
+++ b/recipe/0001-Make-and-install-a-pkg-config-file-on-Windows.patch
@@ -3,7 +3,7 @@ From: Marcel Bargull <marcel.bargull@udo.edu>
 Date: Thu, 27 Oct 2022 11:57:38 +0200
 Subject: [PATCH] Make and install a pkg-config file on Windows
 
-Adapted from
+Adapted from 
 https://github.com/conda-forge/libxml2-feedstock/blob/a4e77d2a8486ec016cde621446ef820b5e0718e2/recipe/0002-Make-and-install-a-pkg-config-file-on-Windows.patch
 ---
  win32/Makefile.msvc | 33 ++++++++++++++++++++++++++++++++-

--- a/recipe/0002-win-profiler-config.patch
+++ b/recipe/0002-win-profiler-config.patch
@@ -1,3 +1,4 @@
+
 --- win32/configure.js
 +++ win32/configure.js
 @@ -43,6 +43,7 @@

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,8 +21,8 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - make        # [not win]
-    - m2-patch    # [win]
     - gnuconfig   # [not win]
     - pkg-config
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.1.41" %}
+{% set version = "1.1.43" %}
 
 package:
   name: libxslt
@@ -7,7 +7,7 @@ package:
 source:
   fn: libxslt-{{ version }}.tar.xz
   url: https://download.gnome.org/sources/libxslt/{{ version[0:3] }}/libxslt-{{ version }}.tar.xz
-  sha256: 3ad392af91115b7740f7b50d228cc1c5fc13afc1da7f16cb0213917a37f71bda
+  sha256: 5a3d6b383ca5afc235b171118e90f5ff6aa27e9fea3303065231a6d403f0183a
   patches:  # [win]
     - 0001-Make-and-install-a-pkg-config-file-on-Windows.patch  # [win]
     - 0002-win-profiler-config.patch  # [win]


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-10347](https://anaconda.atlassian.net/browse/PKG-10347)
- [Upstream repository](https://gitlab.gnome.org/GNOME/libxslt/-/tree/v1.1.43?ref_type=tags)
- [Upstream changelog/diff](https://gitlab.gnome.org/GNOME/libxslt/-/compare/v1.1.42...v1.1.43?from_project_id=1762)

### Explanation of changes:

- New version and sha256
- Add stdlib c
- Ensure patches are LF


[PKG-10347]: https://anaconda.atlassian.net/browse/PKG-10347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ